### PR TITLE
Updates to .NET 10

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,6 +17,16 @@ dotnet_diagnostic.CS1998.severity = suggestion
 # Reason: it could be too verbose to use it everywhere, but this is a good reminder
 dotnet_diagnostic.CA1848.severity = suggestion
 
+# CA1416: This call site is reachable on all platforms. 'User32.MSLLHOOKSTRUCT.pt' is only supported on: 'windows'.
+dotnet_diagnostic.CA1416.severity = none
+
+# CA1873: Evaluation of this argument may be expensive and unnecessary if logging is disabled
+# Reason: logging performance is not critical in our context, and this warning is too aggressive
+dotnet_diagnostic.CA1873.severity = none
+
+# CA1515: Because an application's API isn't typically referenced from outside the assembly, types can be made internal
+dotnet_diagnostic.CA1515.severity = none
+
 # CA1822: Member 'GetPagedResult' does not access instance data and can be marked as static
 # Reason: it may be more convenient to preserve a method as non-static
 dotnet_diagnostic.CA1822.severity = suggestion

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,14 +15,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Install .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '10.0.x'
 
       - name: Get branch and tag
         id: branch_name
@@ -51,9 +51,9 @@ jobs:
       - name: Build and package
         working-directory: ./WinSyncScroll
         run: |
-          dotnet publish -c release -r win-x64 --framework net8.0-windows --self-contained
+          dotnet publish -c release -r win-x64 --framework net10.0-windows --self-contained
           dotnet publish -c release -r win-x64 --framework net462
-          7z a WinSyncScroll_win-x64_net8.0-windows.zip ./bin/release/net8.0-windows/win-x64/publish/*
+          7z a WinSyncScroll_win-x64_net10.0-windows.zip ./bin/release/net10.0-windows/win-x64/publish/*
           7z a WinSyncScroll_win-x64_net462.zip ./bin/release/net462/win-x64/publish/*
 
       - name: Publish
@@ -64,5 +64,5 @@ jobs:
           make_latest: ${{ steps.ref_info.outputs.MAKE_LATEST }}
           generate_release_notes: true
           files: |
-            ./WinSyncScroll/WinSyncScroll_win-x64_net8.0-windows.zip
+            ./WinSyncScroll/WinSyncScroll_win-x64_net10.0-windows.zip
             ./WinSyncScroll/WinSyncScroll_win-x64_net462.zip

--- a/ShowWndProcMessages/ShowWndProcMessages.csproj
+++ b/ShowWndProcMessages/ShowWndProcMessages.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>WinExe</OutputType>
-        <TargetFrameworks>net462;net8.0-windows</TargetFrameworks>
+        <TargetFrameworks>net462;net10.0-windows</TargetFrameworks>
         <EnableWindowsTargeting>true</EnableWindowsTargeting>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
@@ -12,9 +12,9 @@
 
     <ItemGroup>
       <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.3" />
-      <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.3" />
-      <PackageReference Include="PropertyChanged.SourceGenerator" Version="1.1.1">
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
+      <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.0" />
+      <PackageReference Include="PropertyChanged.SourceGenerator" Version="1.1.2">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>

--- a/WinSyncScroll.sln
+++ b/WinSyncScroll.sln
@@ -1,8 +1,19 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 18
+VisualStudioVersion = 18.0.11205.157 d18.0
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WinSyncScroll", "WinSyncScroll\WinSyncScroll.csproj", "{FB6EF979-B67D-4623-BA41-84E53056DFE0}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ShowWndProcMessages", "ShowWndProcMessages\ShowWndProcMessages.csproj", "{01998BC3-C9BD-41CB-AA56-56097401DB2E}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{6F91F047-0FBA-4CAD-83F9-6E6E2CF2B4E9}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+		.gitignore = .gitignore
+		global.json = global.json
+		README.md = README.md
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -18,5 +29,11 @@ Global
 		{01998BC3-C9BD-41CB-AA56-56097401DB2E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{01998BC3-C9BD-41CB-AA56-56097401DB2E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{01998BC3-C9BD-41CB-AA56-56097401DB2E}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {669A0E66-A3F9-40FA-88EA-93F6C580DE5E}
 	EndGlobalSection
 EndGlobal

--- a/WinSyncScroll/Services/MouseHook.cs
+++ b/WinSyncScroll/Services/MouseHook.cs
@@ -86,42 +86,34 @@ public sealed class MouseHook : IDisposable
                 || wParam == WinApiConstants.WM_MOUSEHWHEEL
                 || wParam == WinApiConstants.WM_MOUSEMOVE))
         {
-            var mouseLowLevelDataObj = Marshal.PtrToStructure(lParam, typeof(User32.MSLLHOOKSTRUCT));
-            if (mouseLowLevelDataObj is null)
-            {
-                _logger.LogWarning("Failed to marshal {NameOfLParam} to {NameOfStruct}", nameof(lParam), nameof(User32.MSLLHOOKSTRUCT));
-            }
-            else
-            {
-                var mouseLowLevelData = (User32.MSLLHOOKSTRUCT)mouseLowLevelDataObj;
+            var mouseLowLevelData = Marshal.PtrToStructure<User32.MSLLHOOKSTRUCT>(lParam);
 
-                if (mouseLowLevelData.IsInjected())
-                {
-                    // we have nothing to do with injected events
-                    _logger.LogTrace("Ignoring injected mouse event: {MouseLowLevelData}", mouseLowLevelData.ToLogString());
-                }
-                else if (_sourceRect is not null
-                         && WinApiUtils.PointInRect(_sourceRect, mouseLowLevelData.pt.X, mouseLowLevelData.pt.Y)
-                         && (wParam == WinApiConstants.WM_MOUSEWHEEL
-                             || wParam == WinApiConstants.WM_MOUSEHWHEEL))
-                {
-                    // we should process scroll events in this area
-                    _logger.LogTrace("Mouse scroll event in source rect: {MouseLowLevelData}", mouseLowLevelData.ToLogString());
-                    HookEvents.Writer.TryWrite(new MouseMessageInfo(wParam, mouseLowLevelData));
-                }
-                else if (IsPreventRealScrollEventsActive()
-                         && _targetRect is not null
-                         && WinApiUtils.PointInRect(_targetRect, mouseLowLevelData.pt.X, mouseLowLevelData.pt.Y))
-                {
-                    // prevent the system from passing the message to the rest of the hook chain or the target window procedure
-                    _logger.LogTrace("Preventing real scroll events in target rect: {MouseLowLevelData}", mouseLowLevelData.ToLogString());
-                    return (LRESULT)1;
-                }
-                else if (wParam == WinApiConstants.WM_MOUSEWHEEL
-                         || wParam == WinApiConstants.WM_MOUSEHWHEEL)
-                {
-                    _logger.LogTrace("Ignoring mouse event: {MouseLowLevelData}, because it is not in source rect: {SourceRect}", mouseLowLevelData.ToLogString(), _sourceRect.ToLogString());
-                }
+            if (mouseLowLevelData.IsInjected())
+            {
+                // we have nothing to do with injected events
+                _logger.LogTrace("Ignoring injected mouse event: {MouseLowLevelData}", mouseLowLevelData.ToLogString());
+            }
+            else if (_sourceRect is not null
+                     && WinApiUtils.PointInRect(_sourceRect, mouseLowLevelData.pt.X, mouseLowLevelData.pt.Y)
+                     && (wParam == WinApiConstants.WM_MOUSEWHEEL
+                         || wParam == WinApiConstants.WM_MOUSEHWHEEL))
+            {
+                // we should process scroll events in this area
+                _logger.LogTrace("Mouse scroll event in source rect: {MouseLowLevelData}", mouseLowLevelData.ToLogString());
+                HookEvents.Writer.TryWrite(new MouseMessageInfo(wParam, mouseLowLevelData));
+            }
+            else if (IsPreventRealScrollEventsActive()
+                     && _targetRect is not null
+                     && WinApiUtils.PointInRect(_targetRect, mouseLowLevelData.pt.X, mouseLowLevelData.pt.Y))
+            {
+                // prevent the system from passing the message to the rest of the hook chain or the target window procedure
+                _logger.LogTrace("Preventing real scroll events in target rect: {MouseLowLevelData}", mouseLowLevelData.ToLogString());
+                return (LRESULT)1;
+            }
+            else if (wParam == WinApiConstants.WM_MOUSEWHEEL
+                     || wParam == WinApiConstants.WM_MOUSEHWHEEL)
+            {
+                _logger.LogTrace("Ignoring mouse event: {MouseLowLevelData}, because it is not in source rect: {SourceRect}", mouseLowLevelData.ToLogString(), _sourceRect.ToLogString());
             }
         }
 

--- a/WinSyncScroll/Services/WinApiService.cs
+++ b/WinSyncScroll/Services/WinApiService.cs
@@ -43,7 +43,7 @@ public sealed class WinApiService
                     continue;
                 }
 
-                var (_, processId, errorCode) = PInvoke.GetWindowThreadProcessId(windowHandle);
+                var (_, processId, errorCode) = PInvoke.GetWindowInfo(windowHandle);
                 if (processId == 0 || errorCode != 0)
                 {
                     _logger.LogWarning("Failed to get process ID for window with handle {WindowHandle}", windowHandle);

--- a/WinSyncScroll/ViewModels/MainViewModel.cs
+++ b/WinSyncScroll/ViewModels/MainViewModel.cs
@@ -85,7 +85,7 @@ public sealed partial class MainViewModel : IDisposable
     private int _smCxScreen;
     private int _smCyScreen;
 
-    private static readonly int SizeOfInput = Marshal.SizeOf(typeof(INPUT));
+    private static readonly int SizeOfInput = Marshal.SizeOf<INPUT>();
 
     public MainViewModel(
         ILogger<MainViewModel> logger,
@@ -266,7 +266,7 @@ public sealed partial class MainViewModel : IDisposable
                     if (_options.Value.IsStrictProcessIdCheckEnabled)
                     {
                         var actualSourceWindowHwnd = PInvoke.WindowFromPoint(new Point(sourceEventX, sourceEventY));
-                        var (_, actualSourceProcessId, _) = PInvoke.GetWindowThreadProcessId(actualSourceWindowHwnd);
+                        var (_, actualSourceProcessId, _) = PInvoke.GetWindowInfo(actualSourceWindowHwnd);
 
                         if (actualSourceProcessId != Source.ProcessId)
                         {
@@ -292,7 +292,7 @@ public sealed partial class MainViewModel : IDisposable
                     if (_options.Value.IsStrictProcessIdCheckEnabled)
                     {
                         var actualTargetWindowHwnd = PInvoke.WindowFromPoint(new Point(targetX, targetY));
-                        var (_, actualTargetWindowProcessId, _) = PInvoke.GetWindowThreadProcessId(actualTargetWindowHwnd);
+                        var (_, actualTargetWindowProcessId, _) = PInvoke.GetWindowInfo(actualTargetWindowHwnd);
 
                         if (actualTargetWindowProcessId != Target.ProcessId)
                         {

--- a/WinSyncScroll/WinSyncScroll.csproj
+++ b/WinSyncScroll/WinSyncScroll.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>WinExe</OutputType>
-        <TargetFrameworks>net462;net8.0-windows</TargetFrameworks>
+        <TargetFrameworks>net462;net10.0-windows</TargetFrameworks>
         <EnableWindowsTargeting>true</EnableWindowsTargeting>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
@@ -25,7 +25,7 @@
     <PropertyGroup>
         <!-- Code analysis -->
         <EnableNETAnalyzers>true</EnableNETAnalyzers>
-        <AnalysisLevel>8-all</AnalysisLevel>
+        <AnalysisLevel>10-all</AnalysisLevel>
 
         <!-- Warnings and errors -->
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -42,46 +42,44 @@
       </PackageReference>
       <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
       <PackageReference Include="FontAwesome6.Svg" Version="2.5.1" />
-      <PackageReference Include="Meziantou.Analyzer" Version="2.0.188">
+      <PackageReference Include="Meziantou.Analyzer" Version="2.0.253">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
-      <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.3" />
-      <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.3" />
-      <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.3" />
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.3" />
-      <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.3" />
-      <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.3" />
-      <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.3" />
-      <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.13.2">
+      <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.0" />
+      <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.0" />
+      <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.0" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
+      <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.0" />
+      <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.0" />
+      <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.0" />
+      <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
-      <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.183">
+      <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.242">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
-      <PackageReference Include="Microsoft.Windows.SDK.Win32Metadata" Version="61.0.15-preview" />
-      <PackageReference Include="Microsoft.Windows.WDK.Win32Metadata" Version="0.12.8-experimental" />
       <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.135" />
-      <PackageReference Include="NLog.Extensions.Logging" Version="5.4.0" />
+      <PackageReference Include="NLog.Extensions.Logging" Version="6.1.0" />
       <PackageReference Include="PolySharp" Version="1.15.0">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
-      <PackageReference Include="PropertyChanged.SourceGenerator" Version="1.1.1">
+      <PackageReference Include="PropertyChanged.SourceGenerator" Version="1.1.2">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
-      <PackageReference Include="Roslynator.Analyzers" Version="4.13.1">
+      <PackageReference Include="Roslynator.Analyzers" Version="4.14.1">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
-      <PackageReference Include="Roslynator.Formatting.Analyzers" Version="4.13.1">
+      <PackageReference Include="Roslynator.Formatting.Analyzers" Version="4.14.1">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
-      <PackageReference Include="SonarAnalyzer.CSharp" Version="10.7.0.110445">
+      <PackageReference Include="SonarAnalyzer.CSharp" Version="10.15.0.120848">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
@@ -89,8 +87,8 @@
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
-      <PackageReference Include="System.Threading.Channels" Version="9.0.3" />
-      <PackageReference Include="Vanara.PInvoke.User32" Version="4.1.1" />
+      <PackageReference Include="System.Threading.Channels" Version="10.0.0" />
+      <PackageReference Include="Vanara.PInvoke.User32" Version="4.2.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/WinSyncScroll/Windows.Win32/PInvoke.cs
+++ b/WinSyncScroll/Windows.Win32/PInvoke.cs
@@ -9,7 +9,7 @@ namespace Windows.Win32;
 
 internal partial class PInvoke
 {
-    internal static unsafe (uint ThreadId, uint ProcessId, int errorCode) GetWindowThreadProcessId(HWND hwnd)
+    internal static unsafe (uint ThreadId, uint ProcessId, int errorCode) GetWindowInfo(HWND hwnd)
     {
         uint lpdwProcessId;
         uint* lpdwProcessIdPtr = &lpdwProcessId;

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.0",
+    "version": "10.0.0",
     "rollForward": "latestFeature",
     "allowPrerelease": false
   }


### PR DESCRIPTION
Bumps the target framework to .NET 10.

Updates dependencies to be compatible with .NET 10.

Suppresses CA1416, CA1873, and CA1515 warnings.

Uses generic method Marshal.PtrToStructure<T> to improve code maintainability.
