### PR TITLE
fix potential conversion issue

### DIFF
--- a/WinSyncScroll/ViewModels/MainViewModel.cs
+++ b/WinSyncScroll/ViewModels/MainViewModel.cs
@@ -349,7 +349,7 @@ public sealed partial class MainViewModel : IDisposable
                         List<HWND> allWindows = [(HWND)Target.WindowHandle, ..childWindows];
 
                         // WM_MOUSEWHEEL and WM_MOUSEHWHEEL require screen coordinates in lParam, not client coordinates
-                        var lParam = PInvoke.MAKELPARAM((ushort)targetX, (ushort)targetY);
+                        var lParam = PInvoke.MAKELPARAM(unchecked((ushort)(short)targetX), unchecked((ushort)(short)targetY));
 
                         foreach (var windowHandle in allWindows)
                         {


### PR DESCRIPTION
Coordinates should be cast to short before ushort to handle negative values correctly. Screen coordinates can be negative in multi-monitor setups (e.g., monitors positioned left or above the primary display) and need to preserve their sign using two's complement representation.
