### PR TITLE
Logs result of SendInput and PostMessage calls

### DIFF
--- a/WinSyncScroll/ViewModels/MainViewModel.cs
+++ b/WinSyncScroll/ViewModels/MainViewModel.cs
@@ -382,7 +382,20 @@ public sealed partial class MainViewModel : IDisposable
                                 lParam,
                                 targetX,
                                 targetY);
-                            PInvoke.PostMessage(windowHandle, (uint)buffer.MouseMessageId, (nuint)buffer.MouseMessageData.mouseData, lParam);
+                            
+                            var result = PInvoke.PostMessage(windowHandle, (uint)buffer.MouseMessageId, (nuint)buffer.MouseMessageData.mouseData, lParam);
+                            
+                            if (!result)
+                            {
+                                var lastError = Marshal.GetLastWin32Error();
+                                _logger.LogError("PostMessage failed for window {WindowHandle}: Last Win32 error: {LastError}",
+                                    windowHandle,
+                                    lastError);
+                            }
+                            else
+                            {
+                                _logger.LogTrace("Successfully posted message to window {WindowHandle}", windowHandle);
+                            }
                         }
                     }
                 }

--- a/WinSyncScroll/ViewModels/MainViewModel.cs
+++ b/WinSyncScroll/ViewModels/MainViewModel.cs
@@ -343,7 +343,20 @@ public sealed partial class MainViewModel : IDisposable
                     if (!_options.Value.IsLegacyModeEnabled)
                     {
                         LogSendInput(inputs);
-                        PInvoke.SendInput(inputs.AsSpan(), SizeOfInput);
+                        var sentCount = PInvoke.SendInput(inputs.AsSpan(), SizeOfInput);
+                        
+                        if (sentCount != inputs.Length)
+                        {
+                            var lastError = Marshal.GetLastWin32Error();
+                            _logger.LogError("SendInput failed: expected to send {ExpectedCount} events, but only {SentCount} were sent. Last Win32 error: {LastError}",
+                                inputs.Length,
+                                sentCount,
+                                lastError);
+                        }
+                        else
+                        {
+                            _logger.LogTrace("Successfully sent {SentCount} input events", sentCount);
+                        }
                     }
                     else
                     {


### PR DESCRIPTION
Adds logging to track the number of input events successfully sent by SendInput.

This helps diagnose potential issues where not all input events are processed correctly. It logs an error if the number of sent events doesn't match the expected count and a trace if all events are successfully sent.
